### PR TITLE
feat(open-telemetry): add open telemetry log event enricher

### DIFF
--- a/src/Waystone.Common.Api/DependencyInjection/WaystoneApiHostBuilderExtensions.cs
+++ b/src/Waystone.Common.Api/DependencyInjection/WaystoneApiHostBuilderExtensions.cs
@@ -47,5 +47,6 @@ public static class WaystoneApiHostBuilderExtensions
         loggerConfiguration.ReadFrom.Configuration(configuration);
         loggerConfiguration.Enrich.WithCorrelationIdHeader(configuration, serviceProvider);
         loggerConfiguration.Enrich.WithHttpContext(serviceProvider);
+        loggerConfiguration.Enrich.WithOpenTelemetryContext();
     }
 }

--- a/src/Waystone.Common.Api/Logging/LoggerEnrichmentConfigurationExtensions.cs
+++ b/src/Waystone.Common.Api/Logging/LoggerEnrichmentConfigurationExtensions.cs
@@ -49,4 +49,14 @@ public static class LoggerEnrichmentConfigurationExtensions
 
         return loggerConfig.With(enricher);
     }
+
+    /// <summary>
+    /// Registers the <see cref="OpenTelemetryContextLogEventEnricher" />.
+    /// </summary>
+    /// <param name="config">The <see cref="LoggerEnrichmentConfiguration" />.</param>
+    /// <returns>The <see cref="LoggerConfiguration" />.</returns>
+    public static LoggerConfiguration WithOpenTelemetryContext(this LoggerEnrichmentConfiguration config)
+    {
+        return config.With(new OpenTelemetryContextLogEventEnricher());
+    }
 }

--- a/src/Waystone.Common.Api/Logging/OpenTelemetryContextLogEventEnricher.cs
+++ b/src/Waystone.Common.Api/Logging/OpenTelemetryContextLogEventEnricher.cs
@@ -1,0 +1,21 @@
+﻿namespace Waystone.Common.Api.Logging;
+
+using OpenTelemetry.Trace;
+using Serilog.Core;
+using Serilog.Events;
+
+/// <summary>
+/// Log event enricher for OpenTelemetry.
+/// </summary>
+internal class OpenTelemetryContextLogEventEnricher : ILogEventEnricher
+{
+    /// <inheritdoc />
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        SpanContext context = Tracer.CurrentSpan.Context;
+
+        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("TraceId", context.TraceId.ToHexString()));
+        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("SpanId", context.SpanId.ToHexString()));
+        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("TraceFlags", context.TraceFlags.ToString()));
+    }
+}

--- a/src/Waystone.Common.Api/Waystone.Common.Api.csproj
+++ b/src/Waystone.Common.Api/Waystone.Common.Api.csproj
@@ -33,6 +33,7 @@
         <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.4.2" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.6" />
         <PackageReference Include="NSwag.AspNetCore" Version="13.16.1" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
         <PackageReference Include="Serilog.Filters.Expressions" Version="2.1.0" />
         <PackageReference Include="Serilog.Sinks.Seq" Version="5.1.1" />


### PR DESCRIPTION
Adds `TraceId`, `SpanId`, and `TraceFlags` from `Tracer.CurrentSpan.Context` into the log event if they do not already exist.